### PR TITLE
INSTALL: Allow ./install.sh --prefix=$HOME.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
                                   EYE install
 
-For Linux
----------
+For Linux, MacOS and other Unix look-alikes
+-------------------------------------------
 
 Unzip eye.zip from http://sourceforge.net/projects/eulersharp/files/eulersharp/
 
@@ -9,14 +9,17 @@ Install SWI-Prolog from http://www.swi-prolog.org/Download.html
 Test the SWI-Prolog installation via command line swipl --version
 and it should return the installed version number.
 
-Run the installation script install.sh which will
-- copy the EYE source file eye.pl to /opt/eye/src/eye.pl
-- create the EYE image file at /opt/eye/lib/eye.pvm
-- copy the EYE launch script eye.sh to /opt/eye/bin/eye.sh
-- create a link from /opt/eye/bin/eye.sh to /usr/local/bin/eye
+Run the installation script ``install.sh [--prefix=Prefix]``.  The
+default prefix is /usr/local.  This will
+- create the EYE image file at ``$prefix/lib/eye.pvm``
+- create the EYE launch script eye ub ``$prefix/bin/eye``
 
-Test the EYE installation via command line eye --version
+Test the EYE installation via command line ``eye --version``
 and it should return the version which is in the file VERSION.
+
+For example, to install in your home directory run
+
+    ./install.sh --prefix=$HOME
 
 
 For Windows
@@ -34,24 +37,5 @@ Run the installation script install.cmd which will
 - copy the EYE launch script eye.cmd to C:\Program Files\eye\bin\eye.cmd
 
 Put C:\Program Files\eye\bin in the path environment variable.
-Test the EYE installation via command line eye --version
-and it should return the version which is in the file VERSION.
-
-
-For Mac
--------
-
-Unzip eye.zip from http://sourceforge.net/projects/eulersharp/files/eulersharp/
-
-Install SWI-Prolog from http://www.swi-prolog.org/Download.html
-Test the SWI-Prolog installation via command line swipl --version
-and it should return the installed version number.
-
-Run the installation script install.sh which will
-- copy the EYE source file eye.pl to /opt/eye/src/eye.pl
-- create the EYE image file at /opt/eye/lib/eye.pvm
-- copy the EYE launch script eye.sh to /opt/eye/bin/eye.sh
-- create a link from /opt/eye/bin/eye.sh to /usr/local/bin/eye
-
 Test the EYE installation via command line eye --version
 and it should return the version which is in the file VERSION.

--- a/eye.sh.in
+++ b/eye.sh.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+swipl -x @PREFIX@/lib/eye.pvm -- "$@"

--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,35 @@
 # --------------------------
 # installing EYE in /opt/eye
 # --------------------------
-SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
-mkdir -p /opt/eye/src
-cp -a $SCRIPT_DIR/eye.pl /opt/eye/src
-mkdir -p /opt/eye/lib
-pushd /opt/eye/lib
-swipl -q -f ../src/eye.pl -g main -- --image eye.pvm
-popd
-mkdir -p /opt/eye/bin
-cp -a $SCRIPT_DIR/eye.sh /opt/eye/bin
-ln -sf /opt/eye/bin/eye.sh /usr/local/bin/eye
+
+prefix=/opt/eye
+
+usage()
+{ cat << _EOM_
+Install eye
+
+Usage: $0 [--prefix=dir]
+_EOM_
+}
+
+done=no
+while [ $done = no ]; do
+  case "$1" in
+    --prefix=*)
+      prefix="$(echo $1 | sed 's/[^=]*=//')"
+      shift
+      ;;
+    -*)
+      usage
+      exit 1
+      ;;
+    *)
+      done=yes
+  esac
+done
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+mkdir -p "$prefix/lib" "$prefix/bin" || exit 1
+swipl -q -f "$SCRIPT_DIR/eye.pl" -g main -- --image "$prefix/lib/eye.pvm" || exit 1
+sed "s#@PREFIX@#$prefix#g" "$SCRIPT_DIR/eye.sh.in" > "$prefix/bin/eye" || exit 1
+chmod 755 "$prefix/bin/eye"


### PR DESCRIPTION
Also simplifies the installation a bit and removed the MacOS instructions
as they seem the same as Linux while this also applies for similar systems such as *BSD.