### PR TITLE
Fixing namespace + localName built-ins

### DIFF
--- a/eye.pl
+++ b/eye.pl
@@ -6590,8 +6590,16 @@ djiti_assertz(A) :-
         (   nonvar(A)
         ),
         (   sub_atom(A, 1, _, 1, C),
-            sub_atom_last(C, _, 1, N, '/'),
-            sub_atom(C, _, N, 0, B)
+            (
+                sub_atom_last(C, _, 1, N, '#') ->
+                sub_atom(C, _, N, 0, B)
+                ;
+                sub_atom_last(C, _, 1, N, '/') ->
+                sub_atom(C, _, N, 0, B)
+                ;
+                sub_atom_last(C, _, 1, N, ':') ->
+                sub_atom(C, _, N, 0, B)
+            )
         )
     ).
 
@@ -6614,9 +6622,19 @@ djiti_assertz(A) :-
         (   nonvar(A)
         ),
         (   sub_atom(A, 1, _, 1, C),
-            sub_atom_last(C, N, 1, _, '/'),
-            M is N+1,
-            sub_atom(C, 0, M, _, B)
+            (
+                sub_atom_last(C, N, 1, _, '#') ->
+                M is N+1,
+                sub_atom(C, 0, M, _, B)
+                ;
+                sub_atom_last(C, N, 1, _, '/') ->
+                M is N+1,
+                sub_atom(C, 0, M, _, B)
+                ;
+                sub_atom_last(C, N, 1, _, ':') ->
+                M is N+1,
+                sub_atom(C, 0, M, _, B)
+            )
         )
     ).
 


### PR DESCRIPTION
The log:namespace and log:localName were not working correctly for some namespaces (imo):

Before:

```
<http://somewhere.org/test/localName> log:namespace "http://somewhere.org/test/" .
<http://somewhere.org/test/localName> log:localName "localName" .

<http://somewhere.org/test#localName> log:namespace "http://somewhere.org/" . #!
<http://somewhere.org/test#localName> log:localName "test#localName" . #!

<urn:example.org:localName> log:namespace fail #!!
<urn:example.org:localName> log:localName fail #!!
```

Now

```
<http://somewhere.org/test/localName> log:namespace "http://somewhere.org/test/" .
<http://somewhere.org/test/localName> log:localName "localName" .

<http://somewhere.org/test#localName> log:namespace "http://somewhere.org/test#" . 
<http://somewhere.org/test#localName> log:localName "localName" . 

<urn:example.org:localName> log:namespace "urn:example.org:" 
<urn:example.org:localName> log:localName "localName"
```
