### PR TITLE
chore: automate tagged release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GH_TOKEN }}"
+          prerelease: false
+          files: |
+            *


### PR DESCRIPTION
This automates tagged releases using https://github.com/marvinpinto/action-automatic-releases. Once merged, releases _should_ be made as soon as a new tag is pushed.

I am *assuming* that the use of the `*` glob pattern should mean that all files get included in the release. If you normally do *any* form of pre-processing / before creating a release then do not merge this as we will need to add that pre-processing step to this script.