### PR TITLE
chore: define release tag in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GH_TOKEN }}"
+          automatic_release_tag: "latest"
           prerelease: false
-          files: |
-            *
+          files: "*"


### PR DESCRIPTION
fix for https://github.com/eyereasoner/eye/actions/runs/3839238987/jobs/6536730813