### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: "tagged-release"
 
 on:
-  push:
-    tags:
-      - "v*"
+  create
 
 jobs:
   tagged-release:


### PR DESCRIPTION
The recursive behavior we have been seeing comes from the fact that the action updates the existing tag https://github.com/eyereasoner/eye/actions/runs/3842564189/jobs/6543974071#step:2:25. Thus we should only trigger the action when a tag is created; but not when it is updated.